### PR TITLE
Ensure admin access and visible group for SECIHTI module

### DIFF
--- a/secihti_budget/security/sec_security.xml
+++ b/secihti_budget/security/sec_security.xml
@@ -1,9 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="0">
+        <record id="module_category_secihti" model="ir.module.category">
+            <field name="name">SECIHTI</field>
+            <field name="parent_id" ref="base.module_category_project_management"/>
+            <field name="sequence">25</field>
+        </record>
+
         <record id="group_sec_admin" model="res.groups">
-            <field name="name">Admin SECIHTI</field>
-            <field name="category_id" ref="base.module_category_hidden"/>
+            <field name="name">Administrador SECIHTI</field>
+            <field name="category_id" ref="secihti_budget.module_category_secihti"/>
+        </record>
+
+        <record id="base.group_system" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('secihti_budget.group_sec_admin'))]"/>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
## Summary
- create a dedicated security category for the SECIHTI module
- ensure the administrator group automatically gains SECIHTI permissions
- expose the SECIHTI admin group so it can be assigned to users from the settings UI

## Testing
- python3 -m compileall secihti_budget

------
https://chatgpt.com/codex/tasks/task_e_68cc74a8b3e8833097b0c6eac51255a5