### PR TITLE
Fix activity fields to avoid mail mixin conflicts

### DIFF
--- a/secihti_budget/models/sec_project.py
+++ b/secihti_budget/models/sec_project.py
@@ -51,7 +51,9 @@ class SecProject(models.Model):
     pct_concurrente = fields.Float(string="% Concurrente", tracking=True, default=50.0)
 
     stage_ids = fields.One2many("sec.stage", "project_id", string="Etapas")
-    activity_ids = fields.One2many("sec.activity", "project_id", string="Actividades")
+    sec_activity_ids = fields.One2many(
+        "sec.activity", "project_id", string="Actividades"
+    )
 
     amount_stages_total = fields.Monetary(
         compute="_compute_stage_amounts",
@@ -258,7 +260,7 @@ class SecStage(models.Model):
         currency_field="currency_id",
     )
 
-    activity_ids = fields.One2many("sec.activity", "stage_id")
+    sec_activity_ids = fields.One2many("sec.activity", "stage_id")
     activity_count = fields.Integer(compute="_compute_activity_count")
     inconsistency_message = fields.Char(compute="_compute_inconsistency_message")
 
@@ -268,7 +270,7 @@ class SecStage(models.Model):
             stage.amount_total = (stage.amount_programa or 0.0) + (stage.amount_concurrente or 0.0)
 
     @api.depends(
-        "activity_ids.exec_total",
+        "sec_activity_ids.exec_total",
         "project_id.pct_programa",
         "project_id.pct_concurrente",
         "project_id.stage_ids",
@@ -292,11 +294,11 @@ class SecStage(models.Model):
 
     def _compute_activity_count(self):
         for stage in self:
-            stage.activity_count = len(stage.activity_ids)
+            stage.activity_count = len(stage.sec_activity_ids)
 
     def _compute_inconsistency_message(self):
         for stage in self:
-            activities_budget = sum(stage.activity_ids.mapped("amount_total"))
+            activities_budget = sum(stage.sec_activity_ids.mapped("amount_total"))
             if stage.amount_total and activities_budget > stage.amount_total:
                 stage.inconsistency_message = _(
                     "La suma del presupuesto de actividades excede el presupuesto de la etapa."

--- a/secihti_budget/views/sec_project_views.xml
+++ b/secihti_budget/views/sec_project_views.xml
@@ -70,7 +70,7 @@
                             </field>
                         </page>
                         <page string="Actividades">
-                            <field name="activity_ids">
+                            <field name="sec_activity_ids">
                                 <tree decoration-danger="traffic_light == 'orange'">
                                     <field name="code"/>
                                     <field name="name"/>

--- a/secihti_budget/views/sec_stage_views.xml
+++ b/secihti_budget/views/sec_stage_views.xml
@@ -50,7 +50,7 @@
                     </div>
                     <notebook>
                         <page string="Actividades">
-                            <field name="activity_ids">
+                            <field name="sec_activity_ids">
                                 <tree editable="bottom" decoration-danger="traffic_light == 'orange'">
                                     <field name="code"/>
                                     <field name="name"/>

--- a/secihti_budget/wizards/export_report_wizard.py
+++ b/secihti_budget/wizards/export_report_wizard.py
@@ -204,7 +204,7 @@ class SecExportReportWizard(models.TransientModel):
                 sheet.write_number(row, 3, stage_total["concurrente"], formats["money"])
                 sheet.write_number(row, 4, stage_total["total"], formats["money"])
                 row += 1
-                for activity in stage.activity_ids:
+                for activity in stage.sec_activity_ids:
                     values = stage_values.get(activity.id, {"programa": 0.0, "concurrente": 0.0, "total": 0.0})
                     sheet.write(row, 0, "Actividad", formats["text"])
                     sheet.write(row, 1, self._format_name(activity), formats["text"])


### PR DESCRIPTION
## Summary
- rename the SECIHTI project and stage activity relations to avoid clashing with the mail activity mixin fields
- update the related views and export wizard logic to use the renamed relations

## Testing
- python -m compileall secihti_budget

------
https://chatgpt.com/codex/tasks/task_e_68cc8a7337148330813a40cecb270749