### PR TITLE
Fix tree decorations requiring computed fields in SECIHTI views

### DIFF
--- a/secihti_budget/views/sec_activity_views.xml
+++ b/secihti_budget/views/sec_activity_views.xml
@@ -13,6 +13,7 @@
                 <field name="amount_concurrente"/>
                 <field name="amount_total"/>
                 <field name="exec_total"/>
+                <field name="traffic_light" invisible="1"/>
             </tree>
         </field>
     </record>

--- a/secihti_budget/views/sec_project_views.xml
+++ b/secihti_budget/views/sec_project_views.xml
@@ -11,6 +11,7 @@
                 <field name="amount_stages_total"/>
                 <field name="amount_executed_total"/>
                 <field name="amount_remaining_total"/>
+                <field name="inconsistency_message" invisible="1"/>
             </tree>
         </field>
     </record>

--- a/secihti_budget/views/sec_stage_views.xml
+++ b/secihti_budget/views/sec_stage_views.xml
@@ -13,6 +13,7 @@
                 <field name="amount_total"/>
                 <field name="exec_total"/>
                 <field name="rem_total"/>
+                <field name="inconsistency_message" invisible="1"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
## Summary
- add hidden helper fields to SECIHTI project, stage, and activity tree views so decoration expressions can be evaluated

## Testing
- python3 -m compileall secihti_budget

------
https://chatgpt.com/codex/tasks/task_e_68cd9bdcb5b08330a3f0852ed02c9f58