### PR TITLE
Ocultar campos SECIHTI si no hay proyecto en OC

### DIFF
--- a/secihti_budget/models/purchase_order.py
+++ b/secihti_budget/models/purchase_order.py
@@ -79,6 +79,11 @@ class PurchaseOrder(models.Model):
     @api.onchange("sec_project_id")
     def _onchange_project(self):
         for order in self:
+            if not order.sec_project_id:
+                order.sec_stage_id = False
+                order.sec_activity_id = False
+                order.sec_rubro_id = False
+                continue
             if order.sec_stage_id and order.sec_stage_id.project_id != order.sec_project_id:
                 order.sec_stage_id = False
             if order.sec_activity_id and order.sec_activity_id.project_id != order.sec_project_id:

--- a/secihti_budget/views/purchase_order_views.xml
+++ b/secihti_budget/views/purchase_order_views.xml
@@ -44,11 +44,16 @@
         <group string="SECIHTI" col="4">
           <field name="sec_project_id" options="{'no_open': False}"
                  context="{'default_company_id': company_id}"/>
-          <field name="sec_stage_id" domain="[('project_id', '=', sec_project_id)]"/>
-          <field name="sec_activity_id" domain="[('stage_id', '=', sec_stage_id)]"/>
-          <field name="sec_rubro_id"/>
-          <field name="sec_total_mxn_manual"/>
-          <field name="sec_mxn_pending" readonly="1"/>
+          <field name="sec_stage_id" domain="[('project_id', '=', sec_project_id)]"
+                 attrs="{'invisible': [('sec_project_id', '=', False)]}"/>
+          <field name="sec_activity_id" domain="[('stage_id', '=', sec_stage_id)]"
+                 attrs="{'invisible': [('sec_project_id', '=', False)]}"/>
+          <field name="sec_rubro_id"
+                 attrs="{'invisible': [('sec_project_id', '=', False)]}"/>
+          <field name="sec_total_mxn_manual"
+                 attrs="{'invisible': [('sec_project_id', '=', False)]}"/>
+          <field name="sec_mxn_pending" readonly="1"
+                 attrs="{'invisible': [('sec_project_id', '=', False)]}"/>
         </group>
       </xpath>
 


### PR DESCRIPTION
## Summary
- Limpia automáticamente los campos de etapa, actividad y rubro cuando se elimina el proyecto SECIHTI en la orden de compra.
- Oculta los campos dependientes de SECIHTI en el formulario hasta que se seleccione un proyecto, mostrando solo el campo de proyecto.

## Testing
- python -m compileall secihti_budget

------
https://chatgpt.com/codex/tasks/task_e_68d170e68168833082f9b2fc4544e1cc