### PR TITLE
Set module icon for SECIHTI budget app

### DIFF
--- a/secihti_budget/__manifest__.py
+++ b/secihti_budget/__manifest__.py
@@ -25,5 +25,6 @@
         "data/sec_rubro_data.xml",
     ],
     "application": True,
+    "icon": "/secihti_budget/static/description/icon.png",
     "installable": True,
 }

--- a/secihti_budget/views/sec_menus.xml
+++ b/secihti_budget/views/sec_menus.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <menuitem id="menu_sec_root" name="SECIHTI" sequence="10" groups="secihti_budget.group_sec_admin" web_icon="base,static/description/icon.png"/>
+    <menuitem id="menu_sec_root" name="SECIHTI" sequence="10" groups="secihti_budget.group_sec_admin" web_icon="secihti_budget,static/description/icon.png"/>
 
     <menuitem id="menu_sec_projects" name="Proyectos" parent="menu_sec_root" action="action_sec_project" sequence="10" groups="secihti_budget.group_sec_admin"/>
     <menuitem id="menu_sec_stages" name="Etapas" parent="menu_sec_root" action="action_sec_stage" sequence="20" groups="secihti_budget.group_sec_admin"/>


### PR DESCRIPTION
## Summary
- configure the module manifest to use the bundled icon
- update the root menu to reuse the module icon asset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d18019ac648330b0516cf80dc3f7c7