### PR TITLE
Prioritize activity rubros in purchase orders

### DIFF
--- a/secihti_budget/views/purchase_order_views.xml
+++ b/secihti_budget/views/purchase_order_views.xml
@@ -49,6 +49,7 @@
           <field name="sec_activity_id" domain="[('stage_id', '=', sec_stage_id)]"
                  attrs="{'invisible': [('sec_project_id', '=', False)]}"/>
           <field name="sec_rubro_id"
+                 context="{'sec_activity_id': sec_activity_id}"
                  attrs="{'invisible': [('sec_project_id', '=', False)]}"/>
           <field name="sec_total_mxn_manual"
                  attrs="{'invisible': [('sec_project_id', '=', False)]}"/>


### PR DESCRIPTION
## Summary
- prioritize rubros linked to the selected SECIHTI activity when searching on purchase orders
- fall back to the rest of the rubros after the activity-specific ones to keep full catalog access
- pass the activity context from the purchase order form to the rubro selector

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd6f4162308330b56d86edba40e1e8