### PR TITLE
Add UI and logic for SECIHTI activity budget transfers

### DIFF
--- a/secihti_budget/__manifest__.py
+++ b/secihti_budget/__manifest__.py
@@ -13,9 +13,11 @@
     ],
     "data": [
         "security/security.xml",
+        "data/sec_budget_transfer_sequence.xml",
         "views/sec_project_views.xml",
         "views/sec_stage_views.xml",
         "views/sec_activity_views.xml",
+        "views/sec_budget_transfer_views.xml",
         "views/sec_rubro_views.xml",
         "views/purchase_order_views.xml",
         "views/import_activity_wizard_views.xml",

--- a/secihti_budget/data/sec_budget_transfer_sequence.xml
+++ b/secihti_budget/data/sec_budget_transfer_sequence.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record id="seq_sec_budget_transfer" model="ir.sequence">
+        <field name="name">Transferencias presupuesto SECIHTI</field>
+        <field name="code">sec.budget.transfer</field>
+        <field name="prefix">TRF%(y)s-</field>
+        <field name="padding">4</field>
+        <field name="company_id" eval="False"/>
+    </record>
+</odoo>

--- a/secihti_budget/models/__init__.py
+++ b/secihti_budget/models/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 from . import sec_project
 from . import purchase_order
+from . import budget_transfer

--- a/secihti_budget/models/budget_transfer.py
+++ b/secihti_budget/models/budget_transfer.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools import float_is_zero
+from odoo.tools.misc import formatLang
+
+
+class SecBudgetTransfer(models.Model):
+    _name = "sec.budget.transfer"
+    _description = "Transferencia presupuestal"
+    _inherit = ["mail.thread", "mail.activity.mixin"]
+    _order = "date desc, id desc"
+
+    name = fields.Char(
+        string="Referencia", default=lambda self: _("Nuevo"), copy=False, tracking=True
+    )
+    activity_id = fields.Many2one(
+        "sec.activity", required=True, tracking=True, ondelete="cascade"
+    )
+    project_id = fields.Many2one(
+        related="activity_id.project_id", store=True, readonly=True
+    )
+    stage_id = fields.Many2one(related="activity_id.stage_id", store=True, readonly=True)
+    currency_id = fields.Many2one(
+        related="activity_id.currency_id", store=True, readonly=True
+    )
+    line_from_id = fields.Many2one(
+        "sec.activity.budget.line",
+        string="Línea origen",
+        required=True,
+        tracking=True,
+        domain="[('activity_id', '=', activity_id)]",
+    )
+    line_to_id = fields.Many2one(
+        "sec.activity.budget.line",
+        string="Línea destino",
+        required=True,
+        tracking=True,
+        domain="[('activity_id', '=', activity_id)]",
+    )
+    amount_programa = fields.Monetary(
+        string="Monto programa",
+        currency_field="currency_id",
+        tracking=True,
+    )
+    amount_concurrente = fields.Monetary(
+        string="Monto concurrente",
+        currency_field="currency_id",
+        tracking=True,
+    )
+    amount = fields.Monetary(
+        string="Total",
+        compute="_compute_amount",
+        store=True,
+        currency_field="currency_id",
+        tracking=True,
+    )
+    date = fields.Date(default=fields.Date.context_today, tracking=True)
+    justification = fields.Text(tracking=True)
+    state = fields.Selection(
+        [
+            ("draft", "Borrador"),
+            ("confirmed", "Confirmado"),
+        ],
+        default="draft",
+        tracking=True,
+    )
+
+    @api.onchange("line_from_id")
+    def _onchange_line_from(self):
+        if self.line_from_id:
+            self.activity_id = self.line_from_id.activity_id
+
+    @api.constrains("line_from_id", "line_to_id", "activity_id")
+    def _check_activity_consistency(self):
+        for transfer in self:
+            if not transfer.line_from_id or not transfer.line_to_id or not transfer.activity_id:
+                continue
+            if transfer.line_from_id.activity_id != transfer.activity_id or transfer.line_to_id.activity_id != transfer.activity_id:
+                raise ValidationError(
+                    _(
+                        "Las líneas seleccionadas deben pertenecer a la actividad indicada en la transferencia."
+                    )
+                )
+
+    @api.depends("amount_programa", "amount_concurrente")
+    def _compute_amount(self):
+        for transfer in self:
+            transfer.amount = (transfer.amount_programa or 0.0) + (
+                transfer.amount_concurrente or 0.0
+            )
+
+    def _get_precision(self):
+        self.ensure_one()
+        currency = self.currency_id or self.env.company.currency_id
+        return currency.rounding or self.env.company.currency_id.rounding
+
+    def _validate_lines(self):
+        for transfer in self:
+            if not transfer.line_from_id or not transfer.line_to_id:
+                raise ValidationError(
+                    _("Debe seleccionar las líneas de origen y destino para la transferencia.")
+                )
+            if transfer.line_from_id == transfer.line_to_id:
+                raise ValidationError(
+                    _("La línea de origen y destino no pueden ser la misma.")
+                )
+            if transfer.line_from_id.activity_id != transfer.activity_id or transfer.line_to_id.activity_id != transfer.activity_id:
+                raise ValidationError(
+                    _(
+                        "Las líneas seleccionadas deben pertenecer a la misma actividad que la transferencia."
+                    )
+                )
+
+    def _validate_amounts(self):
+        for transfer in self:
+            precision = transfer._get_precision()
+            prog = transfer.amount_programa or 0.0
+            conc = transfer.amount_concurrente or 0.0
+            if prog < 0.0 or conc < 0.0:
+                raise ValidationError(
+                    _("Los montos de la transferencia no pueden ser negativos.")
+                )
+            if float_is_zero(prog, precision_rounding=precision) and float_is_zero(
+                conc, precision_rounding=precision
+            ):
+                raise ValidationError(
+                    _("Debe especificar un monto en Programa y/o Concurrente para transferir.")
+                )
+
+    @api.model
+    def create(self, vals):
+        default_name = _("Nuevo")
+        if not vals.get("name") or vals.get("name") == default_name:
+            vals["name"] = (
+                self.env["ir.sequence"].next_by_code("sec.budget.transfer")
+                or default_name
+            )
+        record = super().create(vals)
+        if record.state == "confirmed":
+            record.action_confirm()
+        return record
+
+    def action_confirm(self):
+        for transfer in self:
+            if transfer.state == "confirmed":
+                continue
+            transfer._validate_lines()
+            transfer._validate_amounts()
+
+            transfer.line_from_id.apply_transfer_out(
+                transfer.amount_programa, transfer.amount_concurrente, transfer
+            )
+            transfer.line_to_id.apply_transfer_in(
+                transfer.amount_programa, transfer.amount_concurrente, transfer
+            )
+
+            transfer.write({"state": "confirmed"})
+
+            currency = transfer.currency_id or self.env.company.currency_id
+            body = _(
+                "Transferencia aplicada: %(monto)s (Programa: %(prog)s, Concurrente: %(conc)s).",
+                monto=formatLang(self.env, transfer.amount or 0.0, currency_obj=currency),
+                prog=formatLang(
+                    self.env, transfer.amount_programa or 0.0, currency_obj=currency
+                ),
+                conc=formatLang(
+                    self.env, transfer.amount_concurrente or 0.0, currency_obj=currency
+                ),
+            )
+            transfer.message_post(body="<p>%s</p>" % body, subtype_xmlid="mail.mt_note")
+        return True

--- a/secihti_budget/security/ir.model.access.csv
+++ b/secihti_budget/security/ir.model.access.csv
@@ -9,3 +9,5 @@ access_sec_stage_read,access_sec_stage_read,model_sec_stage,base.group_user,1,0,
 access_sec_activity_read,access_sec_activity_read,model_sec_activity,base.group_user,1,0,0,0
 access_sec_activity_line_read,access_sec_activity_line_read,model_sec_activity_budget_line,base.group_user,1,0,0,0
 access_sec_rubro_read,access_sec_rubro_read,model_sec_rubro,base.group_user,1,0,0,0
+access_sec_budget_transfer,access_sec_budget_transfer,model_sec_budget_transfer,secihti_budget.group_sec_admin,1,1,1,1
+access_sec_budget_transfer_read,access_sec_budget_transfer_read,model_sec_budget_transfer,base.group_user,1,0,0,0

--- a/secihti_budget/views/sec_activity_views.xml
+++ b/secihti_budget/views/sec_activity_views.xml
@@ -64,6 +64,47 @@
                                 </tree>
                             </field>
                         </page>
+                        <page string="Transferencias">
+                            <field name="transfer_ids" context="{'default_activity_id': active_id}">
+                                <tree string="Transferencias" create="true" delete="false">
+                                    <field name="name"/>
+                                    <field name="date"/>
+                                    <field name="line_from_id"/>
+                                    <field name="line_to_id"/>
+                                    <field name="amount"/>
+                                    <field name="state" widget="badge"/>
+                                </tree>
+                                <form string="Transferencia">
+                                    <sheet>
+                                        <group>
+                                            <group>
+                                                <field name="name" readonly="1"/>
+                                                <field name="date"/>
+                                                <field name="activity_id" readonly="1"/>
+                                                <field name="project_id" readonly="1"/>
+                                            </group>
+                                            <group>
+                                                <field name="line_from_id" domain="[('activity_id', '=', activity_id)]"/>
+                                                <field name="line_to_id" domain="[('activity_id', '=', activity_id)]"/>
+                                            </group>
+                                            <group>
+                                                <field name="amount_programa"/>
+                                                <field name="amount_concurrente"/>
+                                                <field name="amount" readonly="1"/>
+                                            </group>
+                                        </group>
+                                        <group>
+                                            <field name="justification"/>
+                                        </group>
+                                        <footer>
+                                            <button name="action_confirm" string="Confirmar" type="object" class="btn-primary" states="draft"/>
+                                            <button string="Cerrar" class="btn-secondary" special="cancel"/>
+                                            <field name="state" widget="statusbar" statusbar_visible="draft,confirmed"/>
+                                        </footer>
+                                    </sheet>
+                                </form>
+                            </field>
+                        </page>
                         <page string="Órdenes de compra">
                             <field name="purchase_order_ids" readonly="1">
                                 <tree>

--- a/secihti_budget/views/sec_budget_transfer_views.xml
+++ b/secihti_budget/views/sec_budget_transfer_views.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_sec_budget_transfer_tree" model="ir.ui.view">
+        <field name="name">sec.budget.transfer.tree</field>
+        <field name="model">sec.budget.transfer</field>
+        <field name="arch" type="xml">
+            <tree string="Transferencias presupuestales">
+                <field name="name"/>
+                <field name="date"/>
+                <field name="activity_id"/>
+                <field name="line_from_id"/>
+                <field name="line_to_id"/>
+                <field name="amount"/>
+                <field name="state" widget="badge"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_sec_budget_transfer_form" model="ir.ui.view">
+        <field name="name">sec.budget.transfer.form</field>
+        <field name="model">sec.budget.transfer</field>
+        <field name="arch" type="xml">
+            <form string="Transferencia presupuestal">
+                <header>
+                    <button name="action_confirm" string="Confirmar" type="object" class="btn-primary" states="draft"/>
+                    <field name="state" widget="statusbar" statusbar_visible="draft,confirmed"/>
+                </header>
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="name" readonly="1"/>
+                            <field name="date"/>
+                            <field name="activity_id" options="{'no_open': True}"/>
+                            <field name="project_id" readonly="1"/>
+                            <field name="stage_id" readonly="1"/>
+                        </group>
+                        <group>
+                            <field name="line_from_id" domain="[('activity_id', '=', activity_id)]"/>
+                            <field name="line_to_id" domain="[('activity_id', '=', activity_id)]"/>
+                        </group>
+                        <group>
+                            <field name="amount_programa"/>
+                            <field name="amount_concurrente"/>
+                            <field name="amount" readonly="1"/>
+                        </group>
+                    </group>
+                    <group>
+                        <field name="justification" attrs="{'readonly': [('state', '=', 'confirmed')]}"/>
+                    </group>
+                </sheet>
+                <div class="oe_chatter">
+                    <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="activity_ids" widget="mail_activity"/>
+                    <field name="message_ids" widget="mail_thread"/>
+                </div>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_sec_budget_transfer_search" model="ir.ui.view">
+        <field name="name">sec.budget.transfer.search</field>
+        <field name="model">sec.budget.transfer</field>
+        <field name="arch" type="xml">
+            <search string="Transferencias">
+                <field name="name"/>
+                <field name="activity_id"/>
+                <field name="line_from_id"/>
+                <field name="line_to_id"/>
+                <filter name="state_draft" string="Borradores" domain="[('state', '=', 'draft')]"/>
+                <filter name="state_confirmed" string="Confirmadas" domain="[('state', '=', 'confirmed')]"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="action_sec_budget_transfer" model="ir.actions.act_window">
+        <field name="name">Transferencias presupuestales</field>
+        <field name="res_model">sec.budget.transfer</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" ref="view_sec_budget_transfer_tree"/>
+        <field name="search_view_id" ref="view_sec_budget_transfer_search"/>
+        <field name="context">{'default_state': 'draft'}</field>
+        <field name="groups_id" eval="[(4, ref('secihti_budget.group_sec_admin'))]"/>
+    </record>
+</odoo>

--- a/secihti_budget/views/sec_menus.xml
+++ b/secihti_budget/views/sec_menus.xml
@@ -5,6 +5,7 @@
     <menuitem id="menu_sec_projects" name="Proyectos" parent="menu_sec_root" action="action_sec_project" sequence="10" groups="secihti_budget.group_sec_admin"/>
     <menuitem id="menu_sec_stages" name="Etapas" parent="menu_sec_root" action="action_sec_stage" sequence="20" groups="secihti_budget.group_sec_admin"/>
     <menuitem id="menu_sec_activities" name="Actividades" parent="menu_sec_root" action="action_sec_activity" sequence="30" groups="secihti_budget.group_sec_admin"/>
+    <menuitem id="menu_sec_transfers" name="Transferencias" parent="menu_sec_root" action="action_sec_budget_transfer" sequence="35" groups="secihti_budget.group_sec_admin"/>
     <menuitem id="menu_sec_rubros" name="Rubros" parent="menu_sec_root" action="action_sec_rubro" sequence="40" groups="secihti_budget.group_sec_admin"/>
 
     <menuitem id="menu_sec_reports" name="Reportes" parent="menu_sec_root" sequence="50" groups="secihti_budget.group_sec_admin"/>


### PR DESCRIPTION
## Summary
- add the `sec.budget.transfer` model with validations, sequence-based identifiers, and chatter notifications when confirming transfers
- expose helper methods and relations on activity budget lines to apply transfers safely and surface them from activities
- provide dedicated menu items, views, and access rules so administrators can manage budget transfers in the UI

## Testing
- python -m compileall secihti_budget

------
https://chatgpt.com/codex/tasks/task_e_68dd80c57cfc8330855b9216fe05d04f