### PR TITLE
Ensure activity budget lines show readable names

### DIFF
--- a/secihti_budget/models/sec_project.py
+++ b/secihti_budget/models/sec_project.py
@@ -578,6 +578,20 @@ class SecActivityBudgetLine(models.Model):
     )
     justification = fields.Text(string="Justificación específica")
 
+    def name_get(self):
+        result = []
+        for line in self:
+            parts = []
+            if line.activity_id:
+                parts.append(line.activity_id.display_name)
+            if line.rubro_id:
+                parts.append(line.rubro_id.display_name)
+            if line.name:
+                parts.append(line.name)
+            display_name = " - ".join(parts) if parts else str(line.id)
+            result.append((line.id, display_name))
+        return result
+
     @api.depends("amount_programa", "amount_concurrente")
     def _compute_total(self):
         for line in self:


### PR DESCRIPTION
## Summary
- add a custom name_get implementation for activity budget lines so they always display meaningful labels
- include the related activity, rubro, and description in the composed display name used by transfers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8845df388330a959bba3a3e446b4