### PR TITLE
Fix blank labels on budget transfer lines

### DIFF
--- a/secihti_budget/models/sec_project.py
+++ b/secihti_budget/models/sec_project.py
@@ -585,6 +585,13 @@ class SecActivityBudgetLine(models.Model):
         "sec.budget.transfer", "line_from_id", string="Transferencias salientes"
     )
 
+    def name_get(self):
+        result = []
+        for line in self:
+            name = line.name or line.rubro_id.display_name or _("Sin descripción")
+            result.append((line.id, name))
+        return result
+
     @api.depends("amount_programa", "amount_concurrente")
     def _compute_total(self):
         for line in self:


### PR DESCRIPTION
## Summary
- ensure activity budget lines fall back to the rubro name when no custom description is set

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd8994c0708330b7f23a99b93c503e