### PR TITLE
Autoasignación de montos en transferencias y alerta en rubros

### DIFF
--- a/secihti_budget/views/sec_activity_views.xml
+++ b/secihti_budget/views/sec_activity_views.xml
@@ -51,7 +51,7 @@
                     <notebook>
                         <page string="Presupuesto por rubro">
                             <field name="budget_line_ids">
-                                <tree editable="bottom" decoration-danger="traffic_light == 'orange'">
+                                <tree editable="bottom" decoration-danger="traffic_light_color == 'orange'">
                                     <field name="name"/>
                                     <field name="rubro_id"/>
                                     <field name="tipo_gasto" readonly="1"/>
@@ -59,7 +59,8 @@
                                     <field name="amount_concurrente"/>
                                     <field name="amount_total"/>
                                     <field name="exec_total" readonly="1"/>
-                                    <field name="traffic_light"/>
+                                    <field name="traffic_light_color" invisible="1"/>
+                                    <field name="traffic_light" widget="badge" options="{'class_field': 'traffic_light_color'}"/>
                                     <field name="justification"/>
                                 </tree>
                             </field>
@@ -90,7 +91,7 @@
                                             <group>
                                                 <field name="amount_programa"/>
                                                 <field name="amount_concurrente"/>
-                                                <field name="amount" readonly="1"/>
+                                                <field name="amount"/>
                                             </group>
                                         </group>
                                         <group>


### PR DESCRIPTION
## Summary
- permitir capturar el monto total de una transferencia y distribuir automáticamente los importes de programa y concurrente según los porcentajes del proyecto
- recalcular los importes de programa y concurrente al crear, editar o cambiar la línea origen de la transferencia
- marcar las líneas presupuestales con transferencias confirmadas como "Con transferencia entre rubros" y mostrar el semáforo en color naranja

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dda4ba87dc8330a3d7e9697c00d961