### PR TITLE
Allow transfers across activities within a stage

### DIFF
--- a/secihti_budget/models/sec_project.py
+++ b/secihti_budget/models/sec_project.py
@@ -582,7 +582,7 @@ class SecActivityBudgetLine(models.Model):
         store=True,
     )
     traffic_light_color = fields.Selection(
-        [("green", "Verde"), ("orange", "Naranja")],
+        [("green", "Verde"), ("warning", "Amarillo"), ("orange", "Naranja")],
         compute="_compute_traffic_light",
         store=True,
     )
@@ -661,7 +661,7 @@ class SecActivityBudgetLine(models.Model):
         for line in self:
             if line.id in lines_with_transfer:
                 line.traffic_light = "orange_transfer"
-                line.traffic_light_color = "orange"
+                line.traffic_light_color = "warning"
             elif line.exec_total > line.amount_total:
                 line.traffic_light = "orange_over"
                 line.traffic_light_color = "orange"

--- a/secihti_budget/views/sec_activity_views.xml
+++ b/secihti_budget/views/sec_activity_views.xml
@@ -51,7 +51,7 @@
                     <notebook>
                         <page string="Presupuesto por rubro">
                             <field name="budget_line_ids">
-                                <tree editable="bottom" decoration-danger="traffic_light_color == 'orange'">
+                                <tree editable="bottom" decoration-danger="traffic_light_color == 'orange'" decoration-warning="traffic_light_color == 'warning'">
                                     <field name="name"/>
                                     <field name="rubro_id"/>
                                     <field name="tipo_gasto" readonly="1"/>
@@ -85,13 +85,13 @@
                                                 <field name="project_id" readonly="1"/>
                                             </group>
                                             <group>
-                                                <field name="line_from_id" domain="[('activity_id', '=', activity_id)]"/>
-                                                <field name="line_to_id" domain="[('activity_id', '=', activity_id)]"/>
+                                                <field name="line_from_id" domain="[('stage_id', '=', stage_id)]"/>
+                                                <field name="line_to_id" domain="[('stage_id', '=', stage_id)]"/>
                                             </group>
                                             <group>
-                                                <field name="amount_programa"/>
-                                                <field name="amount_concurrente"/>
-                                                <field name="amount"/>
+                                                <field name="amount_programa" readonly="1"/>
+                                                <field name="amount_concurrente" readonly="1"/>
+                                                <field name="amount" attrs="{'readonly': [('state', '=', 'confirmed')]}"/>
                                             </group>
                                         </group>
                                         <group>

--- a/secihti_budget/views/sec_budget_transfer_views.xml
+++ b/secihti_budget/views/sec_budget_transfer_views.xml
@@ -35,13 +35,13 @@
                             <field name="stage_id" readonly="1"/>
                         </group>
                         <group>
-                            <field name="line_from_id" domain="[('activity_id', '=', activity_id)]"/>
-                            <field name="line_to_id" domain="[('activity_id', '=', activity_id)]"/>
+                            <field name="line_from_id" domain="[('stage_id', '=', stage_id)]"/>
+                            <field name="line_to_id" domain="[('stage_id', '=', stage_id)]"/>
                         </group>
                         <group>
-                            <field name="amount_programa"/>
-                            <field name="amount_concurrente"/>
-                            <field name="amount" readonly="1"/>
+                            <field name="amount_programa" readonly="1"/>
+                            <field name="amount_concurrente" readonly="1"/>
+                            <field name="amount" attrs="{'readonly': [('state', '=', 'confirmed')]}"/>
                         </group>
                     </group>
                     <group>


### PR DESCRIPTION
## Summary
- allow budget transfers to choose source and destination lines across activities that share the same stage and validate the stage match
- switch the transfer traffic-light indicator to yellow and update the decorations that highlight affected budget lines
- make the total transfer amount the editable field while keeping the Programa/Concurrente breakdown read-only

## Testing
- python3 -m compileall secihti_budget

------
https://chatgpt.com/codex/tasks/task_e_68ddad2fa2a083308cec2cf6c80ff2b9