### PR TITLE
Allow inter-activity budget transfers within same stage

### DIFF
--- a/secihti_budget/models/sec_project.py
+++ b/secihti_budget/models/sec_project.py
@@ -450,7 +450,14 @@ class SecActivity(models.Model):
 
     budget_line_ids = fields.One2many("sec.activity.budget.line", "activity_id")
     transfer_ids = fields.One2many(
-        "sec.budget.transfer", "activity_id", string="Transferencias"
+        "sec.budget.transfer",
+        "activity_from_id",
+        string="Transferencias salientes",
+    )
+    transfer_in_ids = fields.One2many(
+        "sec.budget.transfer",
+        "activity_to_id",
+        string="Transferencias entrantes",
     )
 
     amount_programa = fields.Monetary(
@@ -641,6 +648,9 @@ class SecActivityBudgetLine(models.Model):
         "activity_id.transfer_ids.state",
         "activity_id.transfer_ids.line_from_id",
         "activity_id.transfer_ids.line_to_id",
+        "activity_id.transfer_in_ids.state",
+        "activity_id.transfer_in_ids.line_from_id",
+        "activity_id.transfer_in_ids.line_to_id",
     )
     def _compute_traffic_light(self):
         lines_with_transfer = set()

--- a/secihti_budget/views/sec_activity_views.xml
+++ b/secihti_budget/views/sec_activity_views.xml
@@ -66,10 +66,13 @@
                             </field>
                         </page>
                         <page string="Transferencias">
-                            <field name="transfer_ids" context="{'default_activity_id': active_id}">
+                            <field name="transfer_ids" context="{'default_activity_from_id': active_id, 'default_stage_id': stage_id}">
                                 <tree string="Transferencias" create="true" delete="false">
                                     <field name="name"/>
                                     <field name="date"/>
+                                    <field name="stage_id"/>
+                                    <field name="activity_from_id"/>
+                                    <field name="activity_to_id"/>
                                     <field name="line_from_id"/>
                                     <field name="line_to_id"/>
                                     <field name="amount"/>
@@ -81,12 +84,14 @@
                                             <group>
                                                 <field name="name" readonly="1"/>
                                                 <field name="date"/>
-                                                <field name="activity_id" readonly="1"/>
+                                                <field name="stage_id"/>
+                                                <field name="activity_from_id" readonly="1"/>
+                                                <field name="activity_to_id"/>
                                                 <field name="project_id" readonly="1"/>
                                             </group>
                                             <group>
-                                                <field name="line_from_id" domain="[('activity_id', '=', activity_id)]"/>
-                                                <field name="line_to_id" domain="[('activity_id', '=', activity_id)]"/>
+                                                <field name="line_from_id" domain="[('activity_id', '=', activity_from_id)]"/>
+                                                <field name="line_to_id" domain="[('activity_id', '=', activity_to_id)]"/>
                                             </group>
                                             <group>
                                                 <field name="amount_programa"/>

--- a/secihti_budget/views/sec_budget_transfer_views.xml
+++ b/secihti_budget/views/sec_budget_transfer_views.xml
@@ -7,7 +7,9 @@
             <tree string="Transferencias presupuestales">
                 <field name="name"/>
                 <field name="date"/>
-                <field name="activity_id"/>
+                <field name="stage_id"/>
+                <field name="activity_from_id"/>
+                <field name="activity_to_id"/>
                 <field name="line_from_id"/>
                 <field name="line_to_id"/>
                 <field name="amount"/>
@@ -30,13 +32,14 @@
                         <group>
                             <field name="name" readonly="1"/>
                             <field name="date"/>
-                            <field name="activity_id" options="{'no_open': True}"/>
+                            <field name="stage_id"/>
+                            <field name="activity_from_id" options="{'no_open': True}"/>
+                            <field name="activity_to_id" options="{'no_open': True}"/>
                             <field name="project_id" readonly="1"/>
-                            <field name="stage_id" readonly="1"/>
                         </group>
                         <group>
-                            <field name="line_from_id" domain="[('activity_id', '=', activity_id)]"/>
-                            <field name="line_to_id" domain="[('activity_id', '=', activity_id)]"/>
+                            <field name="line_from_id" domain="[('activity_id', '=', activity_from_id)]"/>
+                            <field name="line_to_id" domain="[('activity_id', '=', activity_to_id)]"/>
                         </group>
                         <group>
                             <field name="amount_programa"/>
@@ -63,7 +66,9 @@
         <field name="arch" type="xml">
             <search string="Transferencias">
                 <field name="name"/>
-                <field name="activity_id"/>
+                <field name="stage_id"/>
+                <field name="activity_from_id"/>
+                <field name="activity_to_id"/>
                 <field name="line_from_id"/>
                 <field name="line_to_id"/>
                 <filter name="state_draft" string="Borradores" domain="[('state', '=', 'draft')]"/>


### PR DESCRIPTION
## Summary
- allow selecting different origin and destination activities for budget transfers while keeping them in the same stage
- update validations and defaults to enforce stage consistency and compute amounts based on the chosen stage
- refresh transfer views to show stage, origin, and destination fields and provide the correct creation context

## Testing
- python -m compileall secihti_budget

------
https://chatgpt.com/codex/tasks/task_e_68deb667fb8883309af720d508729772