### PR TITLE
Make transfer total editable for budget transfers

### DIFF
--- a/secihti_budget/views/sec_budget_transfer_views.xml
+++ b/secihti_budget/views/sec_budget_transfer_views.xml
@@ -42,9 +42,9 @@
                             <field name="line_to_id" domain="[('activity_id', '=', activity_to_id)]"/>
                         </group>
                         <group>
-                            <field name="amount_programa"/>
-                            <field name="amount_concurrente"/>
-                            <field name="amount" readonly="1"/>
+                            <field name="amount"/>
+                            <field name="amount_programa" readonly="1"/>
+                            <field name="amount_concurrente" readonly="1"/>
                         </group>
                     </group>
                     <group>


### PR DESCRIPTION
## Summary
- make the transfer total field editable in the form view
- display programme and concurrent amounts as read-only values derived from the total

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68debd2ead8883309b36bcbf834ad109