### PR TITLE
Add optional purchase order number to CSV export

### DIFF
--- a/secihti_budget/views/purchase_order_export_wizard_views.xml
+++ b/secihti_budget/views/purchase_order_export_wizard_views.xml
@@ -9,6 +9,7 @@
                     <field name="stage_id"/>
                     <field name="state_filter"/>
                     <field name="export_mode"/>
+                    <field name="include_po_number"/>
                 </group>
                 <group attrs="{'invisible': [('file_data', '=', False)]}">
                     <field name="filename" readonly="1"/>

--- a/secihti_budget/wizards/purchase_order_export_wizard.py
+++ b/secihti_budget/wizards/purchase_order_export_wizard.py
@@ -31,6 +31,10 @@ class SecPurchaseOrderExportWizard(models.TransientModel):
         string="Modo de exportación",
         required=True,
     )
+    include_po_number = fields.Boolean(
+        string="Incluir orden de compra",
+        default=False,
+    )
     file_data = fields.Binary(string="Archivo", readonly=True)
     filename = fields.Char(string="Nombre de archivo", readonly=True)
 
@@ -130,6 +134,7 @@ class SecPurchaseOrderExportWizard(models.TransientModel):
                         fecha_pago = self._format_date(line.fecha_pago)
 
                         base_row = {
+                            'no_orden_compra': order.name or "",
                             'no_rubro': no_rubro,
                             'nombre_rubro': nombre_rubro,
                             'no_factura': no_factura,
@@ -189,7 +194,8 @@ class SecPurchaseOrderExportWizard(models.TransientModel):
                     new_rows = self._build_rows_for_order(
                         row_number, order, tipo_aportacion, tipo_gasto,
                         no_rubro, nombre_rubro, monto_total, beneficiario,
-                        no_poliza, observaciones, split_mode
+                        no_poliza, observaciones, split_mode,
+                        no_orden_compra=order.name or "",
                     )
                     rows.extend(new_rows)
                     row_number += len(new_rows)
@@ -197,7 +203,8 @@ class SecPurchaseOrderExportWizard(models.TransientModel):
                 new_rows = self._build_rows_for_order(
                     row_number, order, tipo_aportacion, tipo_gasto,
                     no_rubro, nombre_rubro, monto_total, beneficiario,
-                    no_poliza, observaciones, split_mode
+                    no_poliza, observaciones, split_mode,
+                    no_orden_compra=order.name or "",
                 )
                 rows.extend(new_rows)
                 row_number += len(new_rows)
@@ -207,7 +214,7 @@ class SecPurchaseOrderExportWizard(models.TransientModel):
     def _build_rows_for_order(self, row_number, order, tipo_aportacion,
                               tipo_gasto, no_rubro, nombre_rubro,
                               monto_total, beneficiario, no_poliza,
-                              observaciones, split_mode):
+                              observaciones, split_mode, no_orden_compra=""):
         """Build row(s) when control interno is not available or no lines found.
 
         Returns a list of rows (1 row for single mode, 2 for split mode).
@@ -217,6 +224,7 @@ class SecPurchaseOrderExportWizard(models.TransientModel):
         impuestos_retenidos = 0.0
 
         base_row = {
+            'no_orden_compra': no_orden_compra,
             'no_rubro': no_rubro,
             'nombre_rubro': nombre_rubro,
             'no_factura': order.name or "",
@@ -272,6 +280,10 @@ class SecPurchaseOrderExportWizard(models.TransientModel):
         buffer = io.StringIO()
         fieldnames = [
             'no',
+        ]
+        if self.include_po_number:
+            fieldnames.append('no_orden_compra')
+        fieldnames += [
             'tipo_aportacion',
             'tipo_gasto',
             'no_rubro',
@@ -292,6 +304,7 @@ class SecPurchaseOrderExportWizard(models.TransientModel):
         ]
         headers = {
             'no': 'N°',
+            'no_orden_compra': 'Orden de Compra',
             'tipo_aportacion': 'Tipo de Aportación (Fondo/Concurrente)',
             'tipo_gasto': 'Tipo de Gasto (Corriente/Inversión)',
             'no_rubro': 'N° Rubro',


### PR DESCRIPTION
## Summary
Added functionality to optionally include the purchase order number in the CSV export of the purchase order export wizard.

## Key Changes
- Added `include_po_number` boolean field to the wizard model with default value of `False`
- Updated `_build_csv_rows()` method to pass the purchase order name (`no_orden_compra`) to row building functions
- Updated `_build_rows_for_order()` method signature to accept `no_orden_compra` parameter
- Modified `_build_csv()` method to conditionally include the `no_orden_compra` column in the CSV output based on the `include_po_number` flag
- Added the purchase order number field to the wizard form view
- Added proper CSV header mapping for the purchase order number column ("Orden de Compra")

## Implementation Details
- The purchase order number is extracted from `order.name` with an empty string fallback
- The column is only included in the CSV output when the user explicitly enables the `include_po_number` option
- The field is positioned as the first data column (after the row number) in the CSV output when enabled
- Both single and split export modes properly handle the purchase order number parameter

https://claude.ai/code/session_015P7NBhDadxc5dPZNAQejrN